### PR TITLE
refactor parser errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use treewalk::parser;
 fn transform(
     source: String,
     transform_to: interpreter::TransformTo,
-) -> Result<String, Vec<treewalk::parser::ParseError>> {
+) -> Result<String, Vec<String>> {
     let (tokens, _scanner_errors) = scanner::scan(&source);
     match parser::parse(&tokens) {
         Ok(expr) => Ok(interpreter::interpret(&expr, transform_to)),
@@ -15,12 +15,10 @@ fn transform(
     }
 }
 
-pub fn transform_to_flow(source: String) -> Result<String, Vec<treewalk::parser::ParseError>> {
+pub fn transform_to_flow(source: String) -> Result<String, Vec<String>> {
     transform(source, interpreter::TransformTo::Flow)
 }
 
-pub fn transform_to_typescript(
-    source: String,
-) -> Result<String, Vec<treewalk::parser::ParseError>> {
+pub fn transform_to_typescript(source: String) -> Result<String, Vec<String>> {
     transform(source, interpreter::TransformTo::Typescript)
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,4 +1,5 @@
 use itertools::{multipeek, MultiPeek};
+use std::fmt;
 use std::str;
 
 use crate::data_types::Type;
@@ -24,10 +25,33 @@ pub enum Token {
     DataType(Type),
 }
 
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Token::LeftBrace => write!(f, "LeftBrace"),
+            Token::RightBrace => write!(f, "RightBrace"),
+            Token::Colon => write!(f, "Colon"),
+            Token::Identifier(_) => write!(f, "Identifier"),
+            Token::StringLiteral(_) => write!(f, "String Lireral"),
+            Token::Whitespace => write!(f, "Whitespace"),
+            Token::Graveaccent => write!(f, "Graveaccent"),
+            Token::NextLine => write!(f, "New Line"),
+            Token::LeftBracket => write!(f, "Left Bracket"),
+            Token::RightBracket => write!(f, "Right Bracket"),
+            Token::Star => write!(f, "Asterics"),
+            Token::Type => write!(f, "type keyword"),
+            Token::Struct => write!(f, "Struct keyword"),
+            Token::Binding => write!(f, "Binding keyword"),
+            Token::Json => write!(f, "Json keyword"),
+            Token::DataType(data_type) => write!(f, "{}", data_type),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Position {
     pub line: usize,
-    column: usize,
+    pub column: usize,
 }
 
 impl Position {

--- a/src/treewalk/parser.rs
+++ b/src/treewalk/parser.rs
@@ -6,6 +6,7 @@ use crate::data_types::Type;
 use crate::scanner::*;
 use crate::treewalk::ast::*;
 
+// TODO: Will rethink this macros
 macro_rules! consume_expected_token_with_action {
     ($tokens:expr, $expected:pat, $transform_token:expr, $required_element:expr) => {
         match $tokens.peek().map(|t| &t.token) {
@@ -353,7 +354,7 @@ where
         tokens,
         &Token::StringLiteral(ref literal),
         literal.to_string(),
-        Token::StringLiteral("literal".to_string())
+        Token::StringLiteral("".to_string())
     )?;
     Ok(GoStruct::JSONName(str_literal))
 }
@@ -368,7 +369,7 @@ where
         tokens,
         &Token::StringLiteral(ref literal),
         literal.to_string(),
-        Token::StringLiteral("lireral".to_string())
+        Token::StringLiteral("".to_string())
     )?;
     Ok(GoStruct::Binding)
 }

--- a/src/treewalk/parser.rs
+++ b/src/treewalk/parser.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::iter::Peekable;
 use std::rc::Rc;
 
@@ -32,22 +33,32 @@ macro_rules! consume_expected_token {
 }
 
 #[derive(Debug)]
-pub enum RequiredElement {
-    Identifier,
-    Block,
-    Struct,
-    Colon,
-    StringLiteral,
-}
-
-#[derive(Debug)]
 pub enum ParseError {
     UnexpectedEndOfFile,
     UnknownError,
-    Missing(RequiredElement, Lexeme, Position),
+    Missing(Token, Lexeme, Position),
 }
 
-pub fn parse(tokens: &[TokenWithContext]) -> Result<Vec<GoStruct>, Vec<ParseError>> {
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseError::UnexpectedEndOfFile => write!(f, "Unexpected End Of file"),
+            ParseError::UnknownError => write!(
+                f,
+                "We have encountered an unknown error. This is likely a bug with the library."
+            ),
+            ParseError::Missing(token, lexeme, Position { line, column, .. }) => {
+                write!(
+                    f,
+                    "Expected {} but found `{}` at line {} column {}",
+                    token, lexeme, line, column
+                )
+            }
+        }
+    }
+}
+
+pub fn parse(tokens: &[TokenWithContext]) -> Result<Vec<GoStruct>, Vec<String>> {
     let mut statements = Vec::new();
     let mut errors = Vec::new();
     let mut peekable_tokens = tokens.iter().peekable();
@@ -61,7 +72,7 @@ pub fn parse(tokens: &[TokenWithContext]) -> Result<Vec<GoStruct>, Vec<ParseErro
                 break;
             }
             Err(error) => {
-                errors.push(error);
+                errors.push(format!("{}", error));
             }
         }
     }
@@ -110,8 +121,8 @@ where
     I: Iterator<Item = &'a TokenWithContext>,
 {
     let identifier = consume_expected_identifier(tokens)?;
-    consume_expected_token!(tokens, &Token::Struct, RequiredElement::Struct)?;
-    consume_expected_token!(tokens, &Token::LeftBrace, RequiredElement::Block)?;
+    consume_expected_token!(tokens, &Token::Struct, Token::Struct)?;
+    consume_expected_token!(tokens, &Token::LeftBrace, Token::LeftBrace)?;
     let block = match parse_block(tokens) {
         Ok(block) => block,
         err => return err,
@@ -130,7 +141,7 @@ where
         tokens,
         &Token::Identifier(ref identifier),
         identifier.to_string(),
-        RequiredElement::Identifier
+        Token::Identifier("".to_string())
     )
 }
 
@@ -336,13 +347,13 @@ fn parse_json<'a, I>(tokens: &mut Peekable<I>) -> Result<GoStruct, ParseError>
 where
     I: Iterator<Item = &'a TokenWithContext>,
 {
-    consume_expected_token!(tokens, &Token::Colon, RequiredElement::Colon)?;
+    consume_expected_token!(tokens, &Token::Colon, Token::Colon)?;
 
     let str_literal = consume_expected_token_with_action!(
         tokens,
         &Token::StringLiteral(ref literal),
         literal.to_string(),
-        RequiredElement::StringLiteral
+        Token::StringLiteral("literal".to_string())
     )?;
     Ok(GoStruct::JSONName(str_literal))
 }
@@ -351,13 +362,13 @@ fn parse_binding<'a, I>(tokens: &mut Peekable<I>) -> Result<GoStruct, ParseError
 where
     I: Iterator<Item = &'a TokenWithContext>,
 {
-    consume_expected_token!(tokens, &Token::Colon, RequiredElement::Colon)?;
+    consume_expected_token!(tokens, &Token::Colon, Token::Colon)?;
 
     consume_expected_token_with_action!(
         tokens,
         &Token::StringLiteral(ref literal),
         literal.to_string(),
-        RequiredElement::StringLiteral
+        Token::StringLiteral("lireral".to_string())
     )?;
     Ok(GoStruct::Binding)
 }


### PR DESCRIPTION
This PR refactors the parser errors & returns human readable string of the error received.
for instance

```
["Expected LeftBrace but found `\n` at line 2 column 23"]
```